### PR TITLE
Add gstreamer1.0-plugins-bad

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,7 +2,16 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:bullseye
 
 RUN apt update && apt upgrade -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash -
-RUN apt install -y gcc g++ make build-essential nodejs sox gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-base gstreamer1.0-plugins-base-apps
+RUN install_packages build-essential \
+    gcc \
+    g++ \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-base-appsmake \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-tools \    
+    nodejs \
+    sox 
 RUN npm config set user root && npm install edge-impulse-linux -g --unsafe-perm
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
Edge Impulse fallback to `uvch264src` when running (for rpi using bullseye, see [here](https://github.com/edgeimpulse/edge-impulse-linux-cli/blob/master/library/sensors/gstreamer.ts#L133)) 

Edge Impulse fails with
```
[GST] Starting gst-launch-1.0 with [
  'uvch264src',
  'device=/dev/video0',
  '!',
  'video/x-raw,width=640,height=480',
  '!',
  'videoconvert',
  '!',
  'jpegenc',
  '!',
  'multifilesink',
  'location=test%05d.jpg'
]
```
 Add `gstreamer1.0-plugins-bad` to provide `libgstuvch264.so`